### PR TITLE
double-great/great-great-jekyll-theme@v1.0.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ author:
   name: Katy DeCorah
 
 # Build settings
-remote_theme: double-great/great-great-jekyll-theme@main
+remote_theme: double-great/great-great-jekyll-theme@v1.0.0
 plugins:
   - jekyll-feed
   - jekyll-sitemap


### PR DESCRIPTION
Switching from pulling the theme from `main` branch to a versioned tag.

