### PR TITLE
Ignore Ruby directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ _site
 .sass-cache
 .jekyll-cache
 .jekyll-metadata
-vendor
+vendor/
 node_modules/
+.bundle/


### PR DESCRIPTION
Ignores `vendor` and `.bundle` to avoid a landslide of file changes after running the action added in #68 